### PR TITLE
Refactor record ID generation.

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -191,7 +191,6 @@ The `df` element is more complex. In addition to the rule building blocks docume
 
 The following global variables in the generated stylesheet are available for use in XSL fragments:
 
-* `pRecordId`: The value of the `pRecordId` stylesheet parameter. Defaults to `generate-id()`
 * `vRecordId`: A record ID that is calculated for the current BIBFRAME description, with this priority:
   1. The value of the `pRecordId` parameter, if it is passed to the stylesheet
   2. The value in `/rdf:RDF/bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:identifiedBy/bf:Local/rdf:value`, if there is no `bf:source` property or the `bf:source/bf:Source/rdfs:label` value is "DLC".

--- a/src/compile.xsl
+++ b/src/compile.xsl
@@ -25,21 +25,7 @@
       <xsl:output encoding="UTF-8" method="xml" indent="yes"/>
       <xsl:strip-space elements="*"/>
 
-      <xsl:param name="pRecordId" select="generate-id()"/>
-
-      <xsl:variable name="vRecordId">
-        <xsl:choose>
-          <xsl:when test="$pRecordId = generate-id()">
-            <xsl:choose>
-              <xsl:when test="/rdf:RDF/bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:identifiedBy/bf:Local[not(bf:source) or bf:source/@rdf:resource='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/@rdf:about='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/rdfs:label='DLC']/rdf:value">
-                <xsl:value-of select="/rdf:RDF/bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:identifiedBy/bf:Local[not(bf:source) or bf:source/@rdf:resource='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/@rdf:about='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/rdfs:label='DLC']/rdf:value"/>
-              </xsl:when>
-              <xsl:otherwise><xsl:value-of select="$pRecordId"/></xsl:otherwise>
-            </xsl:choose>
-          </xsl:when>
-          <xsl:otherwise><xsl:value-of select="$pRecordId"/></xsl:otherwise>
-        </xsl:choose>
-      </xsl:variable>
+      <xsl:param name="pRecordId" select="'default'"/>
 
       <xsl:param name="pGenerationDatestamp">
         <xsl:if test="function-available('date:date-time')">
@@ -233,6 +219,21 @@
     <xslt:apply-templates mode="map"/>
 
     <xsl:template match="/">
+
+      <xsl:variable name="vRecordId">
+        <xsl:choose>
+          <xsl:when test="$pRecordId = 'default'">
+            <xsl:choose>
+              <xsl:when test="/rdf:RDF/bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:identifiedBy/bf:Local[not(bf:source) or bf:source/@rdf:resource='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/@rdf:about='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/rdfs:label='DLC']/rdf:value">
+                <xsl:value-of select="/rdf:RDF/bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:identifiedBy/bf:Local[not(bf:source) or bf:source/@rdf:resource='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/@rdf:about='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/rdfs:label='DLC']/rdf:value"/>
+              </xsl:when>
+              <xsl:otherwise><xsl:value-of select="generate-id()"/></xsl:otherwise>
+            </xsl:choose>
+          </xsl:when>
+          <xsl:otherwise><xsl:value-of select="$pRecordId"/></xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
       <marc:record>
 
         <xslt:apply-templates mode="documentFrame"/>
@@ -284,7 +285,9 @@
     <xslt:choose>
       <xslt:when test="bf2marc:context">
         <xslt:for-each select="bf2marc:context">
-          <xsl:apply-templates select="{@xpath}" mode="generate-{parent::*/@tag}"/>
+          <xsl:apply-templates select="{@xpath}" mode="generate-{parent::*/@tag}">
+            <xsl:with-param name="vRecordId" select="$vRecordId"/>
+          </xsl:apply-templates>
         </xslt:for-each>
       </xslt:when>
       <xslt:otherwise>
@@ -308,6 +311,7 @@
         <xslt:when test="(local-name(parent::*) = 'df' and parent::*/@repeatable != 'false') or
                          position() = 1">
           <xsl:template match="{@xpath}" mode="generate-{parent::*/@tag}">
+            <xsl:param name="vRecordId"/>
             <xslt:choose>
               <xslt:when test="local-name(parent::*) = 'cf' or parent::*/@repeatable = 'false'">
                 <xsl:choose>

--- a/test/compile.xspec
+++ b/test/compile.xspec
@@ -30,24 +30,7 @@
                        exclude-result-prefixes="rdf rdfs bf bflc madsrdf local">
         <xslt:output encoding="UTF-8" method="xml" indent="yes"/>
         <xslt:strip-space elements="*"/>
-        <xslt:param name="pRecordId" select="generate-id()"/>
-        <xslt:variable name="vRecordId">
-          <xslt:choose>
-            <xslt:when test="$pRecordId = generate-id()">
-              <xslt:choose>
-                <xslt:when test="/rdf:RDF/bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:identifiedBy/bf:Local[not(bf:source) or bf:source/@rdf:resource='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/@rdf:about='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/rdfs:label='DLC']/rdf:value">
-                  <xslt:value-of select="/rdf:RDF/bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:identifiedBy/bf:Local[not(bf:source) or bf:source/@rdf:resource='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/@rdf:about='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/rdfs:label='DLC']/rdf:value" />
-                </xslt:when>
-                <xslt:otherwise>
-                  <xslt:value-of select="$pRecordId" />
-                </xslt:otherwise>
-              </xslt:choose>
-            </xslt:when>
-            <xslt:otherwise>
-              <xslt:value-of select="$pRecordId" />
-            </xslt:otherwise>
-          </xslt:choose>
-        </xslt:variable>
+        <xslt:param name="pRecordId" select="'default'"/>
         <xslt:param name="pGenerationDatestamp">
           <xslt:if test="function-available('date:date-time')">
             <xslt:value-of select="date:date-time()"/>
@@ -55,6 +38,23 @@
         </xslt:param>
         <xslt:variable name="vCurrentVersion">0.1.0-TEST</xslt:variable>
         <xslt:template match="/">
+          <xslt:variable name="vRecordId">
+            <xslt:choose>
+              <xslt:when test="$pRecordId = 'default'">
+                <xslt:choose>
+                  <xslt:when test="/rdf:RDF/bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:identifiedBy/bf:Local[not(bf:source) or bf:source/@rdf:resource='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/@rdf:about='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/rdfs:label='DLC']/rdf:value">
+                    <xslt:value-of select="/rdf:RDF/bf:Work/bf:adminMetadata/bf:AdminMetadata/bf:identifiedBy/bf:Local[not(bf:source) or bf:source/@rdf:resource='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/@rdf:about='http://id.loc.gov/vocabulary/organizations/dlc' or bf:source/bf:Source/rdfs:label='DLC']/rdf:value" />
+                  </xslt:when>
+                  <xslt:otherwise>
+                    <xslt:value-of select="generate-id()" />
+                  </xslt:otherwise>
+                </xslt:choose>
+              </xslt:when>
+              <xslt:otherwise>
+                <xslt:value-of select="$pRecordId" />
+              </xslt:otherwise>
+            </xslt:choose>
+          </xslt:variable>
           <marc:record/>
         </xslt:template>
         <xslt:template match="text()"/>
@@ -276,7 +276,9 @@
         </bf2marc:cf>
       </x:context>
       <x:expect label="...should generate an apply-templates element">
-        <xslt:apply-templates select="rdf:RDF/bf:Instance" mode="generate-001"/>
+        <xslt:apply-templates select="rdf:RDF/bf:Instance" mode="generate-001">
+          <xslt:with-param name="vRecordId" select="$vRecordId"/>
+        </xslt:apply-templates>
       </x:expect>
     </x:scenario>
   </x:scenario>


### PR DESCRIPTION
Avoid processing the global context to accomodate XSpec limitations. See https://github.com/xspec/xspec/issues/423 for more details. Allows tests to pass for XSpec v1.3.0+.

Resolves #4.