### PR TITLE
Rules for MARC 340 generation.

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -14,7 +14,7 @@ The `Makefile` included with this project will generate a top-level `rules.xml` 
 
 ## XML elements
 
-* `rules`: the root element of any rules document. The `rules` element can contain the elements `version`, `file`, `map`, `cf`, `df`, and `switch`. The order of the rules determines the field order of the generated MARC record.
+* `rules`: the root element of any rules document. The `rules` element can contain the elements `version`, `file`, `map`, `cf`, `df`, `select`, and `switch`. The order of the rules determines the field order of the generated MARC record.
 
 ```xml
 <rules xmlns="http://www.loc.gov/bf2marc">
@@ -137,7 +137,7 @@ The `df` element is more complex. In addition to the rule building blocks docume
 
 * `select`: Use an XPath path expression to select a value for use in the target MARC data element, or a value or nodeset for processing. The output of a `select` element should be a string for use in a MARC data element. Note that the `select` element will also set the context for any contained XPath expressions. The `select` element generates an `xsl:for-each` element in the output stylesheet. In the context of a non-repeatable field or subfield, multiple `select` elements are not allowed.
 
-  * This element can be used with the `cf`, `ind1`, `ind2`, `sf`, `position`, and `case` elements.
+  * This element can be used with the `rules`, `cf`, `ind1`, `ind2`, `sf`, `position`, and `case` elements.
 
 ```xml
 <sf code="b" repeatable="false">

--- a/rules/06-3XX.xml
+++ b/rules/06-3XX.xml
@@ -38,9 +38,6 @@
     </case>
   </switch>
 
-
-  <switch>
-    <case test="bf:Instance/bf:frequency/bf:Frequency">
   <select xpath="bf:Instance/bf:frequency/bf:Frequency">
     <switch>
       <case test="position() = 1">
@@ -69,8 +66,6 @@
       </case>
     </switch>
   </select>
-    </case>
-  </switch>
 
   <df tag="336">
     <context xpath="bf:Work/bf:content/*[local-name()='Content' or

--- a/rules/06-3XX.xml
+++ b/rules/06-3XX.xml
@@ -196,4 +196,81 @@
     </context>
   </df>
 
+  <df tag="340">
+    <context xpath="bf:Instance/bf:baseMaterial/bf:BaseMaterial |
+                    bf:Instance/bf:appliedMaterial/bf:AppliedMaterial |
+                    bf:Instance/bf:productionMethod/bf:ProductionMethod |
+                    bf:Instance/bf:mount/bf:Mount |
+                    bf:Instance/bf:reductionRatio/bf:ReductionRatio |
+                    bf:Work/bf:colorContent/bf:ColorContent |
+                    bf:Instance/bf:systemRequirement |
+                    bf:Instance/bf:generation/bf:Generation |
+                    bf:Instance/bf:layout/bf:Layout |
+                    bf:Instance/bf:bookFormat/bf:BookFormat |
+                    bf:Instance/bf:fontSize/bf:FontSize |
+                    bf:Instance/bf:polarity/bf:Polarity">
+      <ind1 default=" "/>
+      <ind2 default=" "/>
+      <switch>
+        <case test="local-name()='BaseMaterial'">
+          <sf code="a"><select xpath="rdfs:label"/></sf>
+        </case>
+        <case test="local-name()='AppliedMaterial'">
+          <sf code="c"><select xpath="rdfs:label"/></sf>
+        </case>
+        <case test="local-name()='ProductionMethod'">
+          <sf code="d"><select xpath="rdfs:label"/></sf>
+        </case>
+        <case test="local-name()='Mount'">
+          <sf code="e"><select xpath="rdfs:label"/></sf>
+        </case>
+        <case test="local-name()='reductionRatio'">
+          <sf code="f"><select xpath="rdfs:label"/></sf>
+        </case>
+        <case test="local-name()='ColorContent'">
+          <sf code="g"><select xpath="rdfs:label"/></sf>
+        </case>
+        <case test="local-name()='systemRequirement'">
+          <sf code="i"><select xpath="."/></sf>
+        </case>
+        <case test="local-name()='Generation'">
+          <sf code="j"><select xpath="rdfs:label"/></sf>
+        </case>
+        <case test="local-name()='Layout'">
+          <sf code="k"><select xpath="rdfs:label"/></sf>
+        </case>
+        <case test="local-name()='BookFormat'">
+          <sf code="m"><select xpath="rdfs:label"/></sf>
+        </case>
+        <case test="local-name()='FontSize'">
+          <sf code="n"><select xpath="rdfs:label"/></sf>
+        </case>
+        <case test="local-name()='Polarity'">
+          <sf code="o"><select xpath="rdfs:label"/></sf>
+        </case>
+      </switch>
+      <sf code="0">
+        <select xpath="@rdf:about"/>
+      </sf>
+      <sf code="0">
+        <select xpath="bf:identifiedBy/bf:Identifier">
+          <transform>
+            <xsl:variable name="vSource">
+              <xsl:value-of select="bf:source/bf:Source/rdfs:label"/>
+            </xsl:variable>
+            <xsl:choose>
+              <xsl:when test="$vSource != ''">
+                <xsl:value-of select="concat('(',$vSource,')',rdf:value)"/>
+              </xsl:when>
+              <xsl:otherwise><xsl:value-of select="rdf:value"/></xsl:otherwise>
+            </xsl:choose>
+          </transform>
+        </select>
+      </sf>
+      <sf code="2" repeatable="false">
+        <select xpath="bf:source/bf:Source/rdfs:label"/>
+      </sf>
+    </context>
+  </df>
+
 </rules>

--- a/rules/test/data/3XX/340.xml
+++ b/rules/test/data/3XX/340.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0'?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:bf="http://id.loc.gov/ontologies/bibframe/" xmlns:bflc="http://id.loc.gov/ontologies/bflc/" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#">
+  <bf:Instance>
+    <bf:baseMaterial>
+      <bf:BaseMaterial>
+        <rdfs:label>plastic, metal</rdfs:label>
+        <bf:source>
+          <bf:Source>
+            <rdfs:label>rda</rdfs:label>
+          </bf:Source>
+        </bf:source>
+      </bf:BaseMaterial>
+    </bf:baseMaterial>
+  </bf:Instance>
+</rdf:RDF>

--- a/rules/test/tests/06-3XX.xspec
+++ b/rules/test/tests/06-3XX.xspec
@@ -41,4 +41,12 @@
     <x:expect label="generate 338" test="count(//marc:datafield[@tag='338']) = 1"/>
   </x:scenario>
 
+  <x:scenario label="MARC 340">
+    <x:context href="../data/3XX/340.xml"/>
+    <x:expect label="generate 340"
+              test="//marc:datafield[@tag='340']/marc:subfield[@code='a'] = 'plastic, metal'"/>
+    <x:expect label="bf:source property generates $2"
+              test="//marc:datafield[@tag='340']/marc:subfield[@code='2'] = 'rda'"/>
+  </x:scenario>
+
 </x:description>

--- a/src/compile.xsl
+++ b/src/compile.xsl
@@ -324,10 +324,14 @@
 
   <!-- compile rules from included files -->
   <xslt:template match="bf2marc:file" mode="documentFrame">
-    <xslt:apply-templates select="document(.)/bf2marc:rules/bf2marc:file | document(.)/bf2marc:rules/bf2marc:cf | document(.)/bf2marc:rules/bf2marc:df | document(.)/bf2marc:rules/bf2marc:switch" mode="documentFrame"/>
+    <xslt:apply-templates select="document(.)/bf2marc:rules/bf2marc:file | document(.)/bf2marc:rules/bf2marc:cf | document(.)/bf2marc:rules/bf2marc:df | document(.)/bf2marc:rules/bf2marc:switch | document(.)/bf2marc:rules/bf2marc:select" mode="documentFrame"/>
   </xslt:template>
 
   <xslt:template match="bf2marc:switch" mode="documentFrame">
+    <xslt:apply-templates select="." mode="fieldTemplate"/>
+  </xslt:template>
+
+  <xslt:template match="bf2marc:select" mode="documentFrame">
     <xslt:apply-templates select="." mode="fieldTemplate"/>
   </xslt:template>
 


### PR DESCRIPTION
* Compiler update: use `select` as a top-level rules element
* Update 310/321 generation to use top-level `select`
* Rules for MARC 340